### PR TITLE
handling events directly

### DIFF
--- a/src/box_game/p2p.rs
+++ b/src/box_game/p2p.rs
@@ -60,6 +60,10 @@ pub async fn main() {
     let mut remaining_time = 0.;
     loop {
         remaining_time += get_frame_time();
+
+        // get newest info from remotes
+        sess.poll_remote_clients();
+
         while remaining_time >= FPS_INV {
             if sess.current_state() == SessionState::Running {
                 // tell GGRS it is time to advance the frame and handle the requests
@@ -74,18 +78,16 @@ pub async fn main() {
                 }
             }
 
-            // handle GGRS events
-            for event in sess.events() {
-                if let GGRSEvent::WaitRecommendation { skip_frames } = event {
-                    // frames_to_skip += skip_frames
-                }
-                println!("Event: {:?}", event);
-            }
             remaining_time -= FPS_INV;
         }
 
-        // idle
-        sess.poll_remote_clients();
+        // handle GGRS events
+        for event in sess.events() {
+            if let GGRSEvent::WaitRecommendation { skip_frames } = event {
+                // frames_to_skip += skip_frames
+            }
+            println!("Event: {:?}", event);
+        }
 
         // update key state
         game.key_states[0] = is_key_down(KeyCode::W);

--- a/src/box_game/p2p.rs
+++ b/src/box_game/p2p.rs
@@ -61,9 +61,6 @@ pub async fn main() {
     loop {
         remaining_time += get_frame_time();
 
-        // get newest info from remotes
-        sess.poll_remote_clients();
-
         while remaining_time >= FPS_INV {
             if sess.current_state() == SessionState::Running {
                 // tell GGRS it is time to advance the frame and handle the requests
@@ -80,6 +77,9 @@ pub async fn main() {
 
             remaining_time -= FPS_INV;
         }
+
+        // get newest info from remotes
+        sess.poll_remote_clients();
 
         // handle GGRS events
         for event in sess.events() {

--- a/src/box_game/spectator.rs
+++ b/src/box_game/spectator.rs
@@ -40,6 +40,10 @@ pub async fn main() {
     // game loop
     loop {
         remaining_time += get_frame_time();
+
+        // get newest info from remotes
+        sess.poll_remote_clients();
+
         while remaining_time >= FPS_INV {
             if sess.current_state() == SessionState::Running {
                 // tell GGRS it is time to advance the frame and handle the requests
@@ -52,19 +56,16 @@ pub async fn main() {
                 }
             }
 
-            // handle GGRS events
-            for event in sess.events() {
-                println!("Event: {:?}", event);
-                if let GGRSEvent::Disconnected { .. } = event {
-                    panic!("Disconnected from host.");
-                }
-            }
-
             remaining_time -= FPS_INV;
         }
 
-        // idle
-        sess.poll_remote_clients();
+        // handle GGRS events
+        for event in sess.events() {
+            println!("Event: {:?}", event);
+            if let GGRSEvent::Disconnected { .. } = event {
+                panic!("Disconnected from host.");
+            }
+        }
 
         render(&game);
 

--- a/src/box_game/spectator.rs
+++ b/src/box_game/spectator.rs
@@ -41,9 +41,6 @@ pub async fn main() {
     loop {
         remaining_time += get_frame_time();
 
-        // get newest info from remotes
-        sess.poll_remote_clients();
-
         while remaining_time >= FPS_INV {
             if sess.current_state() == SessionState::Running {
                 // tell GGRS it is time to advance the frame and handle the requests
@@ -58,6 +55,9 @@ pub async fn main() {
 
             remaining_time -= FPS_INV;
         }
+
+        // get newest info from remotes
+        sess.poll_remote_clients();
 
         // handle GGRS events
         for event in sess.events() {


### PR DESCRIPTION
just a slight recommendation: 

`sess.poll_remote_clients();` can generate new `GGRSEvent`s, so you could handle the events not only every frame but rather directly.  I assume it won't make much of a difference in practice, though 😉 